### PR TITLE
fix onNewBlockSyncReq

### DIFF
--- a/consensus/vbft/node_sync.go
+++ b/consensus/vbft/node_sync.go
@@ -295,7 +295,7 @@ func (self *Syncer) onNewBlockSyncReq(req *BlockSyncReq) error {
 		log.Errorf("server %d new blockSyncReq startblkNum %d vs %d",
 			self.server.Index, req.startBlockNum, self.nextReqBlkNum)
 	}
-	if req.targetBlockNum <= self.targetBlkNum {
+	if req.targetBlockNum < self.targetBlkNum {
 		return nil
 	}
 	if self.nextReqBlkNum == 1 {


### PR DESCRIPTION
If a previous `onNewBlockSyncReq` failed, later tries should not be denied.

