### PR TITLE
Fix incorrect link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ As outlined in Keavy McMinn's article ["How to write the perfect pull request"](
 Issues
 ------
 
-Feel free to submit issues and enhancement requests [here](https://github.com/ontio/ontology/issues/new). Please consider [how to ask a good question](https://stackoverflow.com/help/how-to-ask) and take the time to research your issue before asking for help.
+Feel free to submit issues and enhancement requests [here](https://github.com/polynetwork/poly/issues/new). Please consider [how to ask a good question](https://stackoverflow.com/help/how-to-ask) and take the time to research your issue before asking for help.
 
 Duplicate questions will be closed.
 


### PR DESCRIPTION
Contributing guidelines were taken from the ontio/ontology repo, but the issue link should be for this repo.