### PR TITLE
Check router start block height to prevent hard forks

### DIFF
--- a/native/service/cross_chain_manager/entrance.go
+++ b/native/service/cross_chain_manager/entrance.go
@@ -133,6 +133,11 @@ func ImportExTransfer(native *native.NativeService) ([]byte, error) {
 	if err != nil {
 		return utils.BYTE_FALSE, err
 	}
+	err = utils.CheckRouterStartBlock(sideChain.Router, native.GetHeight())
+	if err != nil {
+		return utils.BYTE_FALSE, err
+	}
+
 	//1. verify tx
 	txParam, err := handler.MakeDepositProposal(native)
 	if err != nil {

--- a/native/service/header_sync/entrance.go
+++ b/native/service/header_sync/entrance.go
@@ -128,6 +128,10 @@ func SyncGenesisHeader(native *native.NativeService) ([]byte, error) {
 	if err != nil {
 		return utils.BYTE_FALSE, err
 	}
+	err = utils.CheckRouterStartBlock(sideChain.Router, native.GetHeight())
+	if err != nil {
+		return utils.BYTE_FALSE, err
+	}
 
 	err = handler.SyncGenesisHeader(native)
 	if err != nil {
@@ -156,6 +160,10 @@ func SyncBlockHeader(native *native.NativeService) ([]byte, error) {
 	if err != nil {
 		return utils.BYTE_FALSE, err
 	}
+	err = utils.CheckRouterStartBlock(sideChain.Router, native.GetHeight())
+	if err != nil {
+		return utils.BYTE_FALSE, err
+	}
 
 	err = handler.SyncBlockHeader(native)
 	if err != nil {
@@ -181,6 +189,10 @@ func SyncCrossChainMsg(native *native.NativeService) ([]byte, error) {
 	}
 
 	handler, err := GetChainHandler(sideChain.Router)
+	if err != nil {
+		return utils.BYTE_FALSE, err
+	}
+	err = utils.CheckRouterStartBlock(sideChain.Router, native.GetHeight())
 	if err != nil {
 		return utils.BYTE_FALSE, err
 	}

--- a/native/service/utils/params.go
+++ b/native/service/utils/params.go
@@ -17,7 +17,10 @@
 
 package utils
 
-import "github.com/polynetwork/poly/common"
+import (
+	"fmt"
+	"github.com/polynetwork/poly/common"
+)
 
 type BtcNetType int
 
@@ -63,3 +66,18 @@ var (
 	HARMONY_ROUTER          = uint64(21)
 	BYTOM_ROUTER            = uint64(22)
 )
+
+//Check router StartBlock to prevent hard forks
+func CheckRouterStartBlock(router uint64, block uint32) (err error) {
+	var startBLock uint32
+	switch router {
+	case HARMONY_ROUTER, HSC_ROUTER, BYTOM_ROUTER:
+		startBLock = 18823000
+	default:
+		return
+	}
+	if block < startBLock {
+		return fmt.Errorf("not a supported router:%d", router)
+	}
+	return
+}

--- a/native/service/utils/params.go
+++ b/native/service/utils/params.go
@@ -20,6 +20,7 @@ package utils
 import (
 	"fmt"
 	"github.com/polynetwork/poly/common"
+	"github.com/polynetwork/poly/common/config"
 )
 
 type BtcNetType int
@@ -72,11 +73,11 @@ func CheckRouterStartBlock(router uint64, block uint32) (err error) {
 	var startBLock uint32
 	switch router {
 	case HARMONY_ROUTER, HSC_ROUTER, BYTOM_ROUTER:
-		startBLock = 18823000
-	default:
-		return
+		if config.DefConfig.P2PNode.NetworkId == config.NETWORK_ID_MAIN_NET {
+			startBLock = 18823000
+		}
 	}
-	if block < startBLock {
+	if startBLock > 0 && block < startBLock {
 		return fmt.Errorf("not a supported router:%d", router)
 	}
 	return


### PR DESCRIPTION
Add start block height check to prevent hard forks caused by new router transactions issued before node upgrade.